### PR TITLE
Core Dump improvements

### DIFF
--- a/src/types/load_command/mod.rs
+++ b/src/types/load_command/mod.rs
@@ -137,6 +137,7 @@ impl LoadCommand {
         let variant = LcVariant::parse(
             reader.clone(),
             cmd,
+            cmdsize,
             base_offset,
             endian,
             is_64,
@@ -253,6 +254,7 @@ impl LcVariant {
     fn parse(
         reader: RcReader,
         cmd: u32,
+        cmdsize: u32,
         command_offset: usize,
         endian: Endian,
         is_64: bool,
@@ -334,12 +336,12 @@ impl LcVariant {
             }
             LC_THREAD => {
                 std::mem::drop(reader_mut);
-                let c = LcThread::parse(reader, base_offset, endian)?;
+                let c = LcThread::parse(reader, cmdsize, base_offset, endian)?;
                 Ok(Self::Thread(c))
             }
             LC_UNIXTHREAD => {
                 std::mem::drop(reader_mut);
-                let c = LcThread::parse(reader, base_offset, endian)?;
+                let c = LcThread::parse(reader, cmdsize, base_offset, endian)?;
                 Ok(Self::Thread(c))
             }
             LC_ROUTINES => {

--- a/src/types/load_command/mod.rs
+++ b/src/types/load_command/mod.rs
@@ -333,11 +333,13 @@ impl LcVariant {
                 Ok(Self::DyldEnvironment(c))
             }
             LC_THREAD => {
-                let c = reader_mut.ioread_with(endian)?;
+                std::mem::drop(reader_mut);
+                let c = LcThread::parse(reader, base_offset, endian)?;
                 Ok(Self::Thread(c))
             }
             LC_UNIXTHREAD => {
-                let c = reader_mut.ioread_with(endian)?;
+                std::mem::drop(reader_mut);
+                let c = LcThread::parse(reader, base_offset, endian)?;
                 Ok(Self::Thread(c))
             }
             LC_ROUTINES => {

--- a/src/types/load_command/thread_command.rs
+++ b/src/types/load_command/thread_command.rs
@@ -1,16 +1,49 @@
-use scroll::{IOread, SizeWith};
+use crate::RcReader;
+use crate::Result;
+
+use scroll::{IOread};
 
 use std::fmt::Debug;
+use std::io::{Seek, SeekFrom};
 
 use crate::auto_enum_fields::*;
 use schnauzer_derive::AutoEnumFields;
 
 /// `thread_command`
 #[repr(C)]
-#[derive(Debug, IOread, SizeWith, AutoEnumFields)]
+#[derive(AutoEnumFields)]
 pub struct LcThread {
     pub flavor: u32,
     pub count: u32,
     /* struct XXX_thread_state state   thread state for this flavor */
     /* ... */
+
+    state_offset: u64
+}
+
+impl LcThread {
+    pub(super) fn parse(reader: RcReader, base_offset: usize, endian: scroll::Endian) -> Result<Self> {
+        let mut reader_mut = reader.borrow_mut();
+        reader_mut.seek(SeekFrom::Start(base_offset as u64))?;
+
+        let flavor: u32 = reader_mut.ioread_with(endian)?;
+        let count: u32 = reader_mut.ioread_with(endian)?;
+
+        let state_offset = reader_mut.stream_position()?;
+        
+        Ok(LcThread { flavor, count, state_offset })
+    }
+
+    pub fn get_state_offset(&self) -> u64 {
+        self.state_offset
+    }
+}
+
+impl Debug for LcThread {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LcThread")
+            .field("flavor", &self.flavor)
+            .field("count", &self.count)
+            .finish()
+    }
 }

--- a/src/types/load_command/thread_command.rs
+++ b/src/types/load_command/thread_command.rs
@@ -9,8 +9,8 @@ use schnauzer_derive::AutoEnumFields;
 #[repr(C)]
 #[derive(Debug, IOread, SizeWith, AutoEnumFields)]
 pub struct LcThread {
-    flavor: u32,
-    count: u32,
+    pub flavor: u32,
+    pub count: u32,
     /* struct XXX_thread_state state   thread state for this flavor */
     /* ... */
 }

--- a/src/types/load_command/thread_command.rs
+++ b/src/types/load_command/thread_command.rs
@@ -5,14 +5,23 @@ use scroll::{IOread};
 
 use std::fmt::Debug;
 use std::io::{Seek, SeekFrom};
+use std::mem::size_of;
 
 use crate::auto_enum_fields::*;
 use schnauzer_derive::AutoEnumFields;
 
+const LC_THREAD_FLAVOR_HEADER_SIZE: usize = size_of::<u32>() + size_of::<u32>();
+
 /// `thread_command`
 #[repr(C)]
-#[derive(AutoEnumFields)]
+#[derive(AutoEnumFields,Debug)]
 pub struct LcThread {
+    pub flavors: Vec<LcThreadFlavor>
+}
+
+#[repr(C)]
+#[derive(AutoEnumFields)]
+pub struct LcThreadFlavor {
     pub flavor: u32,
     pub count: u32,
     /* struct XXX_thread_state state   thread state for this flavor */
@@ -22,7 +31,30 @@ pub struct LcThread {
 }
 
 impl LcThread {
-    pub(super) fn parse(reader: RcReader, base_offset: usize, endian: scroll::Endian) -> Result<Self> {
+    pub(super) fn parse(reader: RcReader, cmdsize: u32, base_offset: usize, endian: scroll::Endian) -> Result<Self> {
+        let mut flavors = Vec::new();
+        
+        let mut flavor_offset = base_offset;
+        loop { 
+            let flavor = LcThreadFlavor::parse(&reader, flavor_offset, endian)?;
+            if flavor.flavor != 0 && flavor.count != 0 {
+                flavor_offset += LC_THREAD_FLAVOR_HEADER_SIZE + flavor.count as usize * size_of::<u32>();
+                flavors.push(flavor);
+
+                if flavor_offset < base_offset + cmdsize as usize {
+                    continue;
+                }
+            }
+
+            break;
+        }
+
+        Ok(LcThread { flavors })
+    }
+}
+
+impl LcThreadFlavor {
+    pub(super) fn parse(reader: &RcReader, base_offset: usize, endian: scroll::Endian) -> Result<Self> {
         let mut reader_mut = reader.borrow_mut();
         reader_mut.seek(SeekFrom::Start(base_offset as u64))?;
 
@@ -31,7 +63,7 @@ impl LcThread {
 
         let state_offset = reader_mut.stream_position()?;
         
-        Ok(LcThread { flavor, count, state_offset })
+        Ok(LcThreadFlavor { flavor, count, state_offset })
     }
 
     pub fn get_state_offset(&self) -> u64 {
@@ -39,9 +71,9 @@ impl LcThread {
     }
 }
 
-impl Debug for LcThread {
+impl Debug for LcThreadFlavor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LcThread")
+        f.debug_struct("LcThreadFlavor")
             .field("flavor", &self.flavor)
             .field("count", &self.count)
             .finish()


### PR DESCRIPTION
When I was doing some research with the core dump, I made some additional changes to schnauzer to help with analyzing a core dump.

I'll admit that there were some part I'm not really sure how I should handle... Let me know if you need me to make any changes!

# Issues

One issue that I noticed is that the formatting is not great... Not really sure how to fix this...
```
  [36] cmd: LC_THREAD cmdsize: 312
    |*flavors: [LcThreadFlavor { flavor: 6, count: 68 }, LcThreadFlavor { flavor: 7, count: 4 }]
```