### PR TITLE
Fix "already borrowed" Error For LC_SEGMENT

### DIFF
--- a/src/types/load_command/mod.rs
+++ b/src/types/load_command/mod.rs
@@ -266,6 +266,7 @@ impl LcVariant {
         // We assume reader already stay right after `cmd` and `cmdsize`
         match cmd {
             LC_SEGMENT => {
+                std::mem::drop(reader_mut);
                 let c = LcSegment::parse(reader_clone, base_offset, object_file_offset, X64Context::Off(endian))?;
                 Ok(Self::Segment32(c))
             }


### PR DESCRIPTION
Fixes an issue where rust panics due to `reader_mut` not being dropped.

```
thread 'main' panicked at 'already borrowed: BorrowMutError', src/types/load_command/segment_command.rs:41:37
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```